### PR TITLE
Fix latest repo version crash on iOS

### DIFF
--- a/ios/Classes/SwiftAdd2CalendarPlugin.swift
+++ b/ios/Classes/SwiftAdd2CalendarPlugin.swift
@@ -46,8 +46,8 @@ public class SwiftAdd2CalendarPlugin: NSObject, FlutterPlugin {
         let endDate = Date(milliseconds: (args["endDate"] as! Double))
         let alarmInterval = args["alarmInterval"] as? Double
         let allDay = args["allDay"] as! Bool
-        let url = args["url"] as! String
-        
+        let url = (args["url"] as? String) ?? ""
+         
         
         let eventStore = EKEventStore()
         

--- a/ios/Classes/SwiftAdd2CalendarPlugin.swift
+++ b/ios/Classes/SwiftAdd2CalendarPlugin.swift
@@ -48,7 +48,6 @@ public class SwiftAdd2CalendarPlugin: NSObject, FlutterPlugin {
         let allDay = args["allDay"] as! Bool
         let url = (args["url"] as? String) ?? ""
          
-        
         let eventStore = EKEventStore()
         
         eventStore.requestAccess(to: .event, completion: { [weak self] (granted, error) in


### PR DESCRIPTION
- Added event url in iCal
- We have forked repo because we need to get latest version of repo and owner din't release that version after latest merge. - And also for future calendar changes purpose we have forked it.